### PR TITLE
Add initial demo notebook and codespace config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,9 @@
 {
 	"name": "ucc-demo",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
-	"features": {
-		"ghcr.io/devcontainers/features/python:1": {"version" : "3.12"}
-	},
+	"image": "mcr.microsoft.com/devcontainers/python:3.12",
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "python3 -m pip install -r requirements.txt",
+	"postCreateCommand": "pip3 install -r requirements.txt",
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -17,7 +14,7 @@
 				"ms-python.python"
 			],
 			"settings": {
-                "python.defaultInterpreterPath": "/usr/local/python/current/bin/python"
+                "python.defaultInterpreterPath": "/usr/local/bin/python"
             }
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "ucc-demo",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {"version" : "3.12"}
+	},
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "python3 -m pip install -r requirements.txt",
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-toolsai.jupyter",
+				"ms-python.python"
+			],
+			"settings": {
+                "python.defaultInterpreterPath": "/usr/local/python/current/bin/python"
+            }
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+## `ucc-demo`
+
+This repository contains an Jupyter notebook demo of the [Unitary Compiler Collection](https://github.com/unitaryfund/ucc).
+
+## Setup Instructions
+
+### GitHub [Codespaces](https://docs.github.com/en/codespaces/developing-in-a-codespace/creating-a-codespace-for-a-repository#creating-a-codespace-for-a-repository) ***Recommended***
+
+   *To use Codespaces, an active Github account is required.*
+
+1. In the repository, select the green Code button, switch to the Codespaces tab, and click the `Create codespace on main` button.
+
+![image](https://github.com/user-attachments/assets/23d1004b-fc28-4717-a9e2-39e579fa2d35)
+
+2. Codespaces may take a few moments to load while creating the codespace. Once complete, you will be able to select the `ucc-demo.ipynb` notebook from the explore list on the left hand side.
+
+3. When you first execute the notebook, you will first be prompted to select  `Python Environments...` and then the recommended environment (3.12.9) from the `Select Another Kernel` window.
+
+### Local
+If you are running this notebook locally, be sure you have have the `ucc` packaged installed via `pip install ucc` or have followed the [documentation](https://ucc.readthedocs.io/en/latest/#installation) on setting up via poetry.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains an Jupyter notebook demo of the [Unitary Compiler Colle
 
 2. Codespaces may take a few moments to load while creating the codespace. Once complete, you will be able to select the `ucc-demo.ipynb` notebook from the explore list on the left hand side.
 
-3. When you first execute the notebook, you will first be prompted to select  `Python Environments...` and then the recommended environment (3.12.9) from the `Select Another Kernel` window.
+3. When you first execute the notebook, you will first be prompted to select  `Python Environments...` and then the recommended environment (3.12.8) from the `Select Another Kernel` window.
 
 ### Local
 If you are running this notebook locally, be sure you have have the `ucc` packaged installed via `pip install ucc` or have followed the [documentation](https://ucc.readthedocs.io/en/latest/#installation) on setting up via poetry.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# use pre-release version of ucc that has a fix for custom passes
+ucc @ git+https://github.com/unitaryfund/ucc@292-compile-custom-pass
+ipykernel==6.29.5

--- a/ucc-demo.ipynb
+++ b/ucc-demo.ipynb
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You'll notice a much bigger change in this circuit, but again compiling to the default target gateset."
+    "You can see the multi-qubit gate count increased, but that is because we compiled to the more restrictive target gateset."
    ]
   },
   {
@@ -158,7 +158,7 @@
     "## Customizing\n",
     "The above examples highlight the `ucc` design goal of simplicity with reasonable defaults. But what if you want more control? `ucc` provides a few options (with more to come!).\n",
     "\n",
-    "First, `ucc` supports specifying a custom `compiler` class to `compile`. For now, this class should be an instance of the default compiler `UCCDefault1`, which contains a pre-defined set of Qiskit compilation passes. When constriction this class, you can specify a `target_device` to indicate target hardware specific properties that the compiler passes can reference.\n",
+    "First, `ucc.compile` lets you specify a `target_device` to indicate target hardware specific properties that the compiler passes can reference. For now, this is an instance of the `qiskit.transpiler` pass, and if specified, the compiler will run additional passes to confirm to the target device layout.\n",
     "\n",
     "### Coupling\n",
     "For this example, consider a target device with restricted multi-qubit coupling, in this case a linear 4-qubit circuit with only nearest neighbor coupling. Using `cirq` as the front-end:"
@@ -185,8 +185,7 @@
     "    cirq.CNOT(qubits[0], qubits[2]) # <- 0 <> 2 not natively supported by topology\n",
     ")\n",
     "\n",
-    "nn_compiler = UCCDefault1(target_device=target)\n",
-    "cirq_compiled_circuit = compile(cirq_circuit, compiler = nn_compiler)\n",
+    "cirq_compiled_circuit = compile(cirq_circuit, target_device = target)\n",
     "\n",
     "print(cirq_circuit)\n",
     "print(\"------------------------\")\n",
@@ -205,9 +204,9 @@
    "metadata": {},
    "source": [
     "### Passes\n",
-    "For compilation strategies, `ucc` uses a default set of `qiskit` compilation passes in the `UCCDefault1` class. These are a set of `qiskit` passes that showed strong performance in benchmarking. \n",
+    "For compilation strategies, `ucc` uses a default set of `qiskit` compilation passes (which you can inspect in the internal `UCCDefault1` class). These passes that showed strong performance in benchmarking, but expect them to be iterated and improved over time.\n",
     "\n",
-    "However, users are free to add their own passes to this set, or develop their own custom sets of passes. Indeed, we expect this to be an active area of `ucc` development. \n",
+    "However, users are free to append other `qiskit` passes to this set, or to develop their own custom sets of passes. Indeed, we expect this to be an active area of `ucc` development. \n",
     "\n",
     "For now, an example of adding a new pass is below. This toy pass swaos H for X gates, and is just meant as an example of interacting with `ucc` compilation."
    ]
@@ -238,10 +237,7 @@
     "print(\"Pre-compile\")\n",
     "print(cirq_circuit)\n",
     "\n",
-    "\n",
-    "htox_compiler = UCCDefault1()\n",
-    "htox_compiler.pass_manager.append(HtoX())\n",
-    "post_compiler_circuit = compile(cirq_circuit, compiler=htox_compiler)\n",
+    "post_compiler_circuit = compile(cirq_circuit, custom_passes = [HtoX()])\n",
     "\n",
     "print(\"Post-compile\")\n",
     "print(post_compiler_circuit)"

--- a/ucc-demo.ipynb
+++ b/ucc-demo.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is an interactive introduction to `ucc`.\n",
+    "\n",
+    "Unitary Compiler Collection (`ucc`) is a Python library for frontend-agnostic, high performance compilation of quantum circuits. UCC's goal is to gather together the best of open source compilation to make quantum programming simpler, faster, and more scalable. For more details, click the links below and read the `ucc` launch [blogpost](https://unitary.foundation/posts/2025_ucc_launch_blog/)\n",
+    "\n",
+    "[![Repository](https://img.shields.io/badge/GitHub-5C5C5C.svg?logo=github)](https://github.com/unitaryfund/ucc)\n",
+    "[![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg)](https://unitary.foundation)\n",
+    "[![Documentation Status](https://readthedocs.org/projects/ucc/badge/?version=latest)](https://ucc.readthedocs.io/en/latest/?badge=latest)\n",
+    "[![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.foundation)\n",
+    "\n",
+    "The goal of this tutorial is to give you an overview of `ucc` features, and provide an easy entry to test `ucc` on your existing quantum programs, and to explore developing custom compiler passes.\n",
+    "\n",
+    "Note that `ucc` is in its early stages, building mostly on the shoudlers of other libraries like qiskit and qbraid. This notebook gives you a flavor of where `ucc` is heading, but there's plenty of work ahead to drive utility and adoption. Early feedback is precious to ensuring that direction will be fruitful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports used throughout this demo\n",
+    "# Assumes you followed the instructions in the README to setup\n",
+    "# your environment.\n",
+    "import ucc\n",
+    "from ucc import compile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quick start\n",
+    "\n",
+    "By leveraging [qBraid](https://github.com/qBraid/qBraid), UCC interfaces automatically with multiple quantum computing frameworks, including [Qiskit](https://github.com/Qiskit/qiskit), [Cirq](https://github.com/quantumlib/Cirq), and [PyTKET](https://github.com/CQCL/tket) and supports programs in OpenQASM 2 and [OpenQASM 3](https://openqasm.com/).\n",
+    "\n",
+    "The list of supported formats is"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ucc.supported_circuit_formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take `ucc` compile for a spin with `pytket` ([docs](https://docs.quantinuum.com/tket/user-guide/index.html)) and `cirq` ([docs](https://quantumai.google/cirq)) on a simple 2-qubit circuit.\n",
+    "\n",
+    "Starting with `pytket`, let's draw the pre and post compiled-circuits:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Using pytket, show the pre and post compiled basic circuit\n",
+    "import pytket\n",
+    "from pytket.circuit.display import render_circuit_jupyter as Tketdraw\n",
+    "\n",
+    "\n",
+    "tket_circuit = pytket.Circuit(2)\n",
+    "tket_circuit.H(0)\n",
+    "tket_circuit.CX(0, 1)\n",
+    "tket_compiled_circuit = compile(tket_circuit)\n",
+    "\n",
+    "Tketdraw(tket_circuit)\n",
+    "Tketdraw(tket_compiled_circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's do the same using the `cirq` library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cirq\n",
+    "\n",
+    "qubits = cirq.LineQubit.range(2)\n",
+    "cirq_circuit = cirq.Circuit(\n",
+    "    cirq.H(qubits[0]),\n",
+    "    cirq.CNOT(qubits[0], qubits[1])\n",
+    ")\n",
+    "cirq_compiled_circuit = compile(cirq_circuit)\n",
+    "\n",
+    "print(cirq_circuit)\n",
+    "print(\"------------------------\")\n",
+    "print(cirq_compiled_circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's a few things to notice from these toy examples:\n",
+    "\n",
+    "* The same `compile` function is used to compile each circuit, even though they are different front-end formats.\n",
+    "* This default `compile` has changed to a target gateset with single qubit rotations and controlled-X gates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's step it up a little, and throw a more complex circuit at `ucc`, this time using `qiskit` as the front-end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.circuit.random import random_clifford_circuit\n",
+    "input_gates = [\"cx\", \"cz\", \"cy\", \"swap\", \"x\", \"y\", \"z\", \"s\", \"sdg\", \"h\"]\n",
+    "num_qubits = 10\n",
+    "random_circuit = random_clifford_circuit(\n",
+    "    num_qubits, gates=input_gates, num_gates=10 * num_qubits * num_qubits\n",
+    ")\n",
+    "compiled_random_circuit = compile(random_circuit)\n",
+    "print(f\"Number of multi-qubit gates in original circuit: {random_circuit.num_nonlocal_gates()}\")\n",
+    "print(f\"Gates used in original circuit: {random_circuit.count_ops()}\")\n",
+    "print(f\"Number of multi-qubit gates in compiled circuit: {compiled_random_circuit.num_nonlocal_gates()}\")\n",
+    "print(f\"Gates used in compiled circuit: {compiled_random_circuit.count_ops()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You'll notice a much bigger change in this circuit, but again compiling to the default target gateset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Customizing\n",
+    "The above examples highlight the `ucc` design goal of simplicity with reasonable defaults. But what if you want more control? `ucc` provides a few options (with more to come!).\n",
+    "\n",
+    "First, `ucc` supports specifying a custom `compiler` class to `compile`. For now, this class should be an instance of the default compiler `UCCDefault1`, which contains a pre-defined set of Qiskit compilation passes. When constriction this class, you can specify a `target_device` to indicate target hardware specific properties that the compiler passes can reference.\n",
+    "\n",
+    "### Coupling\n",
+    "For this example, consider a target device with restricted multi-qubit coupling, in this case a linear 4-qubit circuit with only nearest neighbor coupling. Using `cirq` as the front-end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ucc import UCCDefault1\n",
+    "\n",
+    "from qiskit.transpiler import Target\n",
+    "from qiskit.circuit.library import CXGate\n",
+    "# Create a simple target that does not have direct CX between 0 and 2\n",
+    "target = Target(description=\"Fake device\", num_qubits=3)\n",
+    "target.add_instruction(CXGate(), {(0, 1): None, (1, 2): None})\n",
+    "\n",
+    "\n",
+    "qubits = cirq.LineQubit.range(3)\n",
+    "cirq_circuit = cirq.Circuit(\n",
+    "    cirq.CNOT(qubits[0], qubits[1]),\n",
+    "    cirq.CNOT(qubits[0], qubits[2]) # <- 0 <> 2 not natively supported by topology\n",
+    ")\n",
+    "\n",
+    "nn_compiler = UCCDefault1(target_device=target)\n",
+    "cirq_compiled_circuit = compile(cirq_circuit, compiler = nn_compiler)\n",
+    "\n",
+    "print(cirq_circuit)\n",
+    "print(\"------------------------\")\n",
+    "print(cirq_compiled_circuit)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see that the controlled-not gates are now only between nearest neighbors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Passes\n",
+    "For compilation strategies, `ucc` uses a default set of `qiskit` compilation passes in the `UCCDefault1` class. These are a set of `qiskit` passes that showed strong performance in benchmarking. \n",
+    "\n",
+    "However, users are free to add their own passes to this set, or develop their own custom sets of passes. Indeed, we expect this to be an active area of `ucc` development. \n",
+    "\n",
+    "For now, an example of adding a new pass is below. This toy pass swaos H for X gates, and is just meant as an example of interacting with `ucc` compilation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the new pass\n",
+    "from qiskit.transpiler.basepasses import TransformationPass\n",
+    "from qiskit.circuit.library import HGate, XGate\n",
+    "class HtoX(TransformationPass):\n",
+    "        \"\"\"Toy transformation that converts all H gates to X gates\"\"\"\n",
+    "\n",
+    "        def run(self, dag):\n",
+    "            for node in dag.op_nodes():\n",
+    "                if not isinstance(node.op, HGate):\n",
+    "                    continue\n",
+    "                dag.substitute_node(node, XGate())\n",
+    "            return dag\n",
+    "\n",
+    "qubits = cirq.LineQubit.range(1)\n",
+    "cirq_circuit = cirq.Circuit(cirq.H(qubits[0]))\n",
+    "\n",
+    "# Example usage with a cirq circuit, stil showcasing the cross-frontend compatibility\n",
+    "print(\"Pre-compile\")\n",
+    "print(cirq_circuit)\n",
+    "\n",
+    "\n",
+    "htox_compiler = UCCDefault1()\n",
+    "htox_compiler.pass_manager.append(HtoX())\n",
+    "post_compiler_circuit = compile(cirq_circuit, compiler=htox_compiler)\n",
+    "\n",
+    "print(\"Post-compile\")\n",
+    "print(post_compiler_circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "1. Take `ucc` `compile` for a spin on one of your circuits. How did it change behavior?\n",
+    "2. [Contribute](https://ucc.readthedocs.io/en/latest/contributing.html#proposing-a-new-transpiler-pass) a custom optimization pass\n",
+    "3. Join the [discussion](https://github.com/unitaryfund/ucc/discussions) on the evolution of `ucc` \n",
+    "\n",
+    "As mentioned in the [launch blogpost](https://unitary.foundation/posts/2025_ucc_launch_blog/), for development priorities post-launch, we want to focus on what we think is most impactful for the progress of quantum computing – and where we have unique expertise at Unitary Foundation – leveraging our diverse and dynamic quantum open-source community to push into the regime of thousands of qubits, 10s of thousands of gates, where compilers require novel architectures and abstractions to handle errors.\n",
+    "\n",
+    "Key roadmap items include:\n",
+    "\n",
+    "* Quantum Error Mitigation (QEM): Integration with Mitiq, our cross-platform QEM library with 212k+ downloads and 100+ citations.\n",
+    "* Hardware-Aware Compilation: Custom routing and scheduling optimized for emerging architectures.\n",
+    "* Quantum Error Correction (QEC): Implementing early fault tolerance protocols in conjunction with error mitigation\n",
+    "* Hybrid classical-quantum programming: Mid-circuit measurements, fast feedback, repeat-until-success, etc.\n",
+    "\n",
+    "Stay tuned for future demo notebooks with these capabilities!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This repository and initial comment fixes https://github.com/unitaryfund/ucc/issues/296.

I decided to go with a separate repository over adding directly to the `ucc` repo to keep management cleaner and avoid it interfering with normal `ucc` development workflow.

For now, I did need to put a development version of `ucc` in the `requirements.txt` file until a version with https://github.com/unitaryfund/ucc/pull/293 is released.

You should be able to try out the Github codespace, by selecting this initial-prototype [branch](https://github.com/unitaryfund/ucc-demo/tree/initial-prototype), clicking the code/codespace to launch one for this branch.
<img width="963" alt="image" src="https://github.com/user-attachments/assets/d06c8a03-1710-4ba0-adb9-a46f11dd3fc6" />

I'm not yet sure how codespace caches the images, but for the first time the codespace was setup, it took a few minutes to install the right version of python and the requirements. If that is the same for others, I can look into speeding it up.
